### PR TITLE
Upgraded Strophe to 1.2.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8088,9 +8088,9 @@
       "dev": true
     },
     "strophe.js": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/strophe.js/-/strophe.js-1.2.15.tgz",
-      "integrity": "sha512-aM5SCLltSLKubPNil28ieJ03I+15jcVX02c1/7SBVIUWRfwfxwondRJSMJpB7OBss5b3jCNxpTqig8nXncJ5yg=="
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/strophe.js/-/strophe.js-1.2.16.tgz",
+      "integrity": "sha512-r/Uq7aqrusg25Y0qHwV48cFnMY6K/CuZdGt3EggRx3kY4sMv8lG+AFoMlrmTcYVMG1BaJvQfv9Cthw4Ll8z7fQ=="
     },
     "strophejs-plugin-disco": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash.isequal": "4.5.0",
     "react-native-callstats": "3.53.4",
     "sdp-transform": "2.3.0",
-    "strophe.js": "1.2.15",
+    "strophe.js": "1.2.16",
     "strophejs-plugin-disco": "0.0.2",
     "webrtc-adapter": "github:webrtc/adapter#1eec19782b4058d186341263e7d049cea3e3290a",
     "yaeti": "1.0.1"


### PR DESCRIPTION
Strophe 1.2.16 contains a fix for a bug (https://github.com/strophe/strophejs/issues/299) that also appears when using lib-jitsi-meet with ejabberd.